### PR TITLE
feat: add Google Analytics support

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Oswald, DM_Sans } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
+import { GoogleAnalytics } from "@next/third-parties/google";
 import { resolveConfig, formatTemplate } from "@/config/env";
 import "./globals.css";
 
@@ -83,6 +84,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         />
         {children}
         <Analytics />
+        {process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID && (
+          <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID} />
+        )}
       </body>
     </html>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "kampioen",
       "version": "0.1.0",
       "dependencies": {
+        "@next/third-parties": "^16.1.6",
         "@vercel/analytics": "^1.6.1",
         "next": "16.1.6",
         "react": "19.2.3",
@@ -1594,6 +1595,18 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.1.6.tgz",
+      "integrity": "sha512-/cLY1egaH529ylSMSK+C8dA3nWDLL4hOFR4fca9OLWWxjcNwzsbuq2pPb/tmdWL9Zj3K1nTjd1pWQoSlaDQ0VA==",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -6602,6 +6615,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA=="
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build-all": "tsx scripts/build-all.ts"
   },
   "dependencies": {
+    "@next/third-parties": "^16.1.6",
     "@vercel/analytics": "^1.6.1",
     "next": "16.1.6",
     "react": "19.2.3",


### PR DESCRIPTION
## Summary
- Adds `@next/third-parties` package for optimized Google Analytics integration
- Renders `<GoogleAnalytics>` component in the root layout when `NEXT_PUBLIC_GA_MEASUREMENT_ID` env var is set
- No-op in environments without the env var configured

## Test plan
- [x] Build passes with `TARGET_LEAGUE=eredivisie npm run build`
- [ ] Set `NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX` in `.env.local` and verify gtag script loads in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)