### PR TITLE
feat: make sitemap and robots.txt use dynamic club domain

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,11 +1,13 @@
 import type { MetadataRoute } from "next";
+import { resolveConfig } from "@/config/env";
 
 export default function robots(): MetadataRoute.Robots {
+  const { club } = resolveConfig();
   return {
     rules: {
       userAgent: "*",
       allow: "/",
     },
-    sitemap: "https://psvkampioen.nl/sitemap.xml",
+    sitemap: `https://${club.domain}/sitemap.xml`,
   };
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,9 +1,11 @@
 import type { MetadataRoute } from "next";
+import { resolveConfig } from "@/config/env";
 
 export default function sitemap(): MetadataRoute.Sitemap {
+  const { club } = resolveConfig();
   return [
     {
-      url: "https://psvkampioen.nl",
+      url: `https://${club.domain}`,
       lastModified: new Date(),
       changeFrequency: "daily",
       priority: 1,


### PR DESCRIPTION
## Summary
- `app/sitemap.ts` and `app/robots.txt` previously hardcoded `psvkampioen.nl`
- Now both use `resolveConfig()` to read `club.domain`, so URLs adapt automatically to whichever club is deployed (PSV, Ajax, Feyenoord, etc.)

## Test plan
- [ ] Build succeeds for each TARGET_CLUB (psv, ajax, feyenoord)
- [ ] `/sitemap.xml` shows the correct domain per club
- [ ] `/robots.txt` references the correct sitemap URL per club

🤖 Generated with [Claude Code](https://claude.com/claude-code)