### PR TITLE
feat: use SITE_URL env var as canonical domain

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { Oswald, DM_Sans } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
 import { GoogleAnalytics } from "@next/third-parties/google";
-import { resolveConfig, formatTemplate } from "@/config/env";
+import { resolveConfig, formatTemplate, getSiteUrl } from "@/config/env";
 import "./globals.css";
 
 const oswald = Oswald({
@@ -33,7 +33,7 @@ export const viewport: Viewport = {
 };
 
 export const metadata: Metadata = {
-  metadataBase: new URL(`https://${club.domain}`),
+  metadataBase: new URL(getSiteUrl()),
   alternates: {
     canonical: "/",
   },
@@ -66,7 +66,7 @@ const jsonLd = {
   "@type": "WebSite",
   name: formatTemplate(texts.schemaName, templateVars),
   description: formatTemplate(texts.schemaDescription, templateVars),
-  url: `https://${club.domain}`,
+  url: getSiteUrl(),
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,13 +1,12 @@
 import type { MetadataRoute } from "next";
-import { resolveConfig } from "@/config/env";
+import { getSiteUrl } from "@/config/env";
 
 export default function robots(): MetadataRoute.Robots {
-  const { club } = resolveConfig();
   return {
     rules: {
       userAgent: "*",
       allow: "/",
     },
-    sitemap: `https://${club.domain}/sitemap.xml`,
+    sitemap: `${getSiteUrl()}/sitemap.xml`,
   };
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,11 +1,11 @@
 import type { MetadataRoute } from "next";
-import { resolveConfig } from "@/config/env";
+import { getSiteUrl } from "@/config/env";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const { club } = resolveConfig();
+  const siteUrl = getSiteUrl();
   return [
     {
-      url: `https://${club.domain}`,
+      url: siteUrl,
       lastModified: new Date(),
       changeFrequency: "daily",
       priority: 1,

--- a/config/env.ts
+++ b/config/env.ts
@@ -50,6 +50,10 @@ export function resolveClub(): ClubConfig {
   return club;
 }
 
+export function getSiteUrl(): string {
+  return process.env.SITE_URL ?? `https://${resolveClub().domain}`;
+}
+
 export function resolveConfig(): ResolvedConfig {
   const league = resolveLeague();
   const club = resolveClub();


### PR DESCRIPTION
## Summary
- Add `getSiteUrl()` to `config/env.ts`: reads `SITE_URL` env var, falls back to `https://{club.domain}`
- `app/sitemap.ts` — uses `getSiteUrl()` instead of hardcoded club domain
- `app/robots.ts` — uses `getSiteUrl()` for the sitemap reference
- `app/layout.tsx` — uses `getSiteUrl()` for both `metadataBase` and JSON-LD `url`

Set `SITE_URL=https://wewordenweerkampioen.nl` (or any deployment domain) in your environment variables — that URL will be used everywhere that matters for SEO.

## Test plan
- [ ] Set `SITE_URL=https://wewordenweerkampioen.nl`, verify sitemap.xml and robots.txt contain that domain
- [ ] Without `SITE_URL`, verify fallback to `club.domain` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)