### PR TITLE
fix: use VERCEL_PROJECT_PRODUCTION_URL as canonical site URL

### DIFF
--- a/config/env.ts
+++ b/config/env.ts
@@ -51,7 +51,9 @@ export function resolveClub(): ClubConfig {
 }
 
 export function getSiteUrl(): string {
-  return process.env.SITE_URL ?? `https://${resolveClub().domain}`;
+  if (process.env.VERCEL_PROJECT_PRODUCTION_URL)
+    return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`;
+  return `https://${resolveClub().domain}`;
 }
 
 export function resolveConfig(): ResolvedConfig {


### PR DESCRIPTION
## Summary
- Replace manual `SITE_URL` env var with Vercel's built-in `VERCEL_PROJECT_PRODUCTION_URL`
- Automatically resolves to the shortest custom production domain (e.g. `wewordenweerkampioen.nl`) — no manual config needed
- Falls back to `club.domain` for local / non-Vercel environments

## Test plan
- [ ] On Vercel with a custom domain set: sitemap.xml, robots.txt and JSON-LD url all show the custom domain
- [ ] Locally without `VERCEL_PROJECT_PRODUCTION_URL`: falls back to `club.domain`

🤖 Generated with [Claude Code](https://claude.com/claude-code)