### PR TITLE
feat: add weather forecast for match days

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@ import { join } from "path";
 import type { ClubSimulationResult, DateProbability } from "@/lib/simulation";
 import type { Team, Fixture } from "@/lib/data";
 import { resolveConfig, formatTemplate, toClientLeague } from "@/config/env";
+import { loadWeather } from "@/lib/weather.server";
 import HeroSection from "@/components/HeroSection";
 import ChampionshipTimeline from "@/components/ChampionshipTimeline";
 import BestCaseView from "@/components/BestCaseView";
@@ -106,11 +107,18 @@ function buildFaqJsonLd(result: ClubSimulationResult) {
   };
 }
 
-export default function Home() {
+export default async function Home() {
   const data = loadData();
   const result = data.clubResults[club.id];
   const explanation = data.explanation[club.id];
   const { teams, fixtures, fetchedAt, simulatedAt } = data;
+
+  const weather = await loadWeather(
+    club.id,
+    fixtures,
+    club.coordinates,
+    leagueFull.dataDir
+  );
 
   const faqJsonLd = buildFaqJsonLd(result);
 
@@ -128,6 +136,7 @@ export default function Home() {
         club={club}
         league={league}
         texts={texts}
+        weather={weather}
       />
       <BestCaseView
         bestCaseDate={result.bestCaseDate}
@@ -137,6 +146,7 @@ export default function Home() {
         club={club}
         league={league}
         texts={texts}
+        weather={weather}
       />
       <ChampionshipTimeline
         dates={result.dateProbabilities}
@@ -144,6 +154,7 @@ export default function Home() {
         league={league}
         texts={texts}
         teams={teams}
+        weather={weather}
       />
       <EndOfSeasonPrediction
         clubResults={data.clubResults}

--- a/components/BestCaseView.tsx
+++ b/components/BestCaseView.tsx
@@ -5,7 +5,9 @@ import { SectionHeader } from "./ChampionshipTimeline";
 import type { ClubConfig } from "@/config/clubs";
 import type { LeagueClientConfig } from "@/config/env";
 import type { LocaleStrings } from "@/config/locales/nl";
+import type { WeatherData } from "@/lib/weather";
 import { formatTemplate } from "@/config/env";
+import WeatherBadge from "./WeatherBadge";
 
 function formatDate(dateStr: string, locale: string): string {
   const d = new Date(dateStr);
@@ -25,6 +27,7 @@ export default function BestCaseView({
   club,
   league,
   texts,
+  weather,
 }: {
   bestCaseDate: string | null;
   bestCaseRound: number | null;
@@ -33,6 +36,7 @@ export default function BestCaseView({
   club: ClubConfig;
   league: LeagueClientConfig;
   texts: LocaleStrings;
+  weather: Record<string, WeatherData>;
 }) {
   const clubFixtures = fixtures
     .filter((f) => f.homeTeam === club.id || f.awayTeam === club.id)
@@ -226,6 +230,11 @@ export default function BestCaseView({
                 </p>
                 <p style={{ fontSize: "0.7rem", color: "#444", marginTop: "2px" }}>
                   {formatShortDate(f.date, league.locale)} · {f.isHome ? texts.bestCaseHome : texts.bestCaseAway}
+                  {" "}
+                  <WeatherBadge
+                    weather={weather[f.date.slice(0, 10)]}
+                    expectedLabel={texts.weatherExpected}
+                  />
                   {f.isChampionMatch && (
                     <span
                       style={{

--- a/components/ChampionshipTimeline.tsx
+++ b/components/ChampionshipTimeline.tsx
@@ -5,7 +5,9 @@ import type { Team } from "@/lib/data";
 import type { ClubConfig } from "@/config/clubs";
 import type { LeagueClientConfig } from "@/config/env";
 import type { LocaleStrings } from "@/config/locales/nl";
+import type { WeatherData } from "@/lib/weather";
 import { formatTemplate } from "@/config/env";
+import WeatherBadge from "./WeatherBadge";
 
 function formatDate(dateStr: string, locale: string): string {
   const d = new Date(dateStr);
@@ -18,12 +20,14 @@ export default function ChampionshipTimeline({
   league,
   texts,
   teams,
+  weather,
 }: {
   dates: DateProbability[];
   club: ClubConfig;
   league: LeagueClientConfig;
   texts: LocaleStrings;
   teams: Team[];
+  weather: Record<string, WeatherData>;
 }) {
   const maxProb = Math.max(...dates.map((d) => d.probability));
 
@@ -109,6 +113,10 @@ export default function ChampionshipTimeline({
                   <p style={{ fontSize: "0.72rem", color: "#666", marginTop: "1px" }}>
                     {dp.isHome ? `${texts.timelineVs} ` : `${texts.timelineAt} `}{opponentName}
                   </p>
+                  <WeatherBadge
+                    weather={weather[dp.date.slice(0, 10)]}
+                    expectedLabel={texts.weatherExpected}
+                  />
                 </div>
 
                 {/* Bars */}

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -6,7 +6,9 @@ import type { Explanation } from "@/app/page";
 import type { ClubConfig } from "@/config/clubs";
 import type { LeagueClientConfig } from "@/config/env";
 import type { LocaleStrings } from "@/config/locales/nl";
+import type { WeatherData } from "@/lib/weather";
 import { formatTemplate } from "@/config/env";
+import WeatherBadge from "./WeatherBadge";
 
 function formatDate(dateStr: string, locale: string): string {
   const d = new Date(dateStr);
@@ -27,6 +29,7 @@ export default function HeroSection({
   club,
   league,
   texts,
+  weather,
 }: {
   result: ClubSimulationResult;
   explanation: Explanation;
@@ -35,6 +38,7 @@ export default function HeroSection({
   club: ClubConfig;
   league: LeagueClientConfig;
   texts: LocaleStrings;
+  weather: Record<string, WeatherData>;
 }) {
   const [showExplanation, setShowExplanation] = useState(false);
 
@@ -205,10 +209,26 @@ export default function HeroSection({
           <StatCard
             label={texts.statBestCase}
             value={result.bestCaseDate ? formatDate(result.bestCaseDate, league.locale) : "?"}
+            weatherBadge={
+              result.bestCaseDate ? (
+                <WeatherBadge
+                  weather={weather[result.bestCaseDate.slice(0, 10)]}
+                  expectedLabel={texts.weatherExpected}
+                />
+              ) : undefined
+            }
           />
           <StatCard
             label={texts.statMostLikely}
             value={topProb ? formatDate(topProb.date, league.locale) : "?"}
+            weatherBadge={
+              topProb ? (
+                <WeatherBadge
+                  weather={weather[topProb.date.slice(0, 10)]}
+                  expectedLabel={texts.weatherExpected}
+                />
+              ) : undefined
+            }
           />
         </div>
 
@@ -467,7 +487,7 @@ export default function HeroSection({
   );
 }
 
-function StatCard({ label, value, highlight }: { label: string; value: string; highlight?: boolean }) {
+function StatCard({ label, value, highlight, weatherBadge }: { label: string; value: string; highlight?: boolean; weatherBadge?: React.ReactNode }) {
   return (
     <div
       style={{
@@ -501,6 +521,7 @@ function StatCard({ label, value, highlight }: { label: string; value: string; h
       >
         {value}
       </p>
+      {weatherBadge}
     </div>
   );
 }

--- a/components/WeatherBadge.tsx
+++ b/components/WeatherBadge.tsx
@@ -1,0 +1,38 @@
+import type { WeatherData } from "@/lib/weather";
+import { categoryToIcon } from "@/lib/weather";
+
+export default function WeatherBadge({
+  weather,
+  expectedLabel,
+}: {
+  weather: WeatherData | undefined;
+  expectedLabel: string;
+}) {
+  if (!weather) return null;
+
+  const icon = categoryToIcon(weather.category);
+  const tempMin = Math.round(weather.temperatureMin);
+  const tempMax = Math.round(weather.temperatureMax);
+
+  return (
+    <span
+      style={{
+        fontSize: "0.8rem",
+        color: "#666",
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "3px",
+      }}
+    >
+      <span style={{ fontSize: "1.2rem" }}>{icon}</span>
+      <span>
+        {tempMin}&ndash;{tempMax}&deg;
+      </span>
+      {weather.source === "historical-estimate" && (
+        <span style={{ color: "#555", fontStyle: "italic" }}>
+          ({expectedLabel})
+        </span>
+      )}
+    </span>
+  );
+}

--- a/config/clubs.ts
+++ b/config/clubs.ts
@@ -15,6 +15,7 @@ export interface ClubConfig {
   domain: string;
   kofiUrl?: string;
   locale: string;
+  coordinates: { latitude: number; longitude: number };
   textOverrides?: Partial<LocaleStrings>;
 }
 
@@ -36,6 +37,7 @@ export const clubs: Record<string, ClubConfig> = {
     domain: "psvkampioen.nl",
     kofiUrl: "https://ko-fi.com/baslijten",
     locale: "nl",
+    coordinates: { latitude: 51.4416, longitude: 5.4697 },
   },
   ajax: {
     id: "ajax",
@@ -47,6 +49,7 @@ export const clubs: Record<string, ClubConfig> = {
     primaryColorGlow: "rgba(210,18,46,0.25)",
     domain: "ajaxkampioen.nl",
     locale: "nl",
+    coordinates: { latitude: 52.3676, longitude: 4.9041 },
   },
   feyenoord: {
     id: "feyenoord",
@@ -58,5 +61,6 @@ export const clubs: Record<string, ClubConfig> = {
     primaryColorGlow: "rgba(238,28,37,0.25)",
     domain: "feyenoordkampioen.nl",
     locale: "nl",
+    coordinates: { latitude: 51.9244, longitude: 4.4777 },
   },
 };

--- a/config/locales/en.ts
+++ b/config/locales/en.ts
@@ -76,6 +76,9 @@ export const en: LocaleStrings = {
   faqEarliestChampion: "When is the earliest {clubName} can become champion?",
   faqEarliestChampionAnswer: "In the best case scenario \u2014 if {clubName} wins all remaining matches \u2014 {clubName} becomes champion on {bestCaseDate}{roundSuffix}.",
 
+  // Weather
+  weatherExpected: "expected",
+
   // Meta
   metaTitleTemplate: "{clubShortName} Champion {season} \u2014 When will {clubShortName} win the {leagueName}?",
   metaDescriptionTemplate: "Monte Carlo simulation with 50,000 scenarios calculates when {clubName} will win the {leagueName} {season}. View probabilities per matchday, best case scenario and current standings.",

--- a/config/locales/nl.ts
+++ b/config/locales/nl.ts
@@ -74,6 +74,9 @@ export interface LocaleStrings {
   faqEarliestChampion: string;
   faqEarliestChampionAnswer: string;
 
+  // Weather
+  weatherExpected: string;
+
   // Meta
   metaTitleTemplate: string;
   metaDescriptionTemplate: string;
@@ -158,6 +161,9 @@ export const nl: LocaleStrings = {
   faqChanceChampionAnswer: "De kans dat {clubName} {leagueName} kampioen wordt is {probability}, berekend op basis van 50.000 gesimuleerde seizoensverloop scenario's.",
   faqEarliestChampion: "Wanneer kan {clubName} op zijn vroegst kampioen worden?",
   faqEarliestChampionAnswer: "In het best case scenario \u2014 als {clubName} alle resterende wedstrijden wint \u2014 wordt {clubName} kampioen op {bestCaseDate}{roundSuffix}.",
+
+  // Weather
+  weatherExpected: "verwacht",
 
   // Meta
   metaTitleTemplate: "{clubShortName} Kampioen {season} \u2014 Wanneer wordt {clubShortName} {leagueName} kampioen?",

--- a/data/eredivisie/weather.json
+++ b/data/eredivisie/weather.json
@@ -1,0 +1,77 @@
+{
+  "fetchedAt": "2026-03-02T20:40:05.280Z",
+  "psv": {
+    "2026-03-22": {
+      "date": "2026-03-22",
+      "weatherCode": 53,
+      "category": "drizzle",
+      "temperatureMax": 17.7,
+      "temperatureMin": 10.8,
+      "precipitationSum": 1.3,
+      "windSpeedMax": 16.5,
+      "source": "historical-estimate"
+    },
+    "2026-04-04": {
+      "date": "2026-04-04",
+      "weatherCode": 0,
+      "category": "sunny",
+      "temperatureMax": 22.3,
+      "temperatureMin": 7.8,
+      "precipitationSum": 0,
+      "windSpeedMax": 13.2,
+      "source": "historical-estimate"
+    },
+    "2026-04-11": {
+      "date": "2026-04-11",
+      "weatherCode": 3,
+      "category": "partly-cloudy",
+      "temperatureMax": 18.6,
+      "temperatureMin": 3,
+      "precipitationSum": 0,
+      "windSpeedMax": 9.5,
+      "source": "historical-estimate"
+    },
+    "2026-04-23": {
+      "date": "2026-04-23",
+      "weatherCode": 61,
+      "category": "rain",
+      "temperatureMax": 15.6,
+      "temperatureMin": 9.4,
+      "precipitationSum": 4.1,
+      "windSpeedMax": 9,
+      "source": "historical-estimate"
+    },
+    "2026-05-02": {
+      "date": "2026-05-02",
+      "weatherCode": 51,
+      "category": "drizzle",
+      "temperatureMax": 27.5,
+      "temperatureMin": 15.4,
+      "precipitationSum": 0.2,
+      "windSpeedMax": 18.3,
+      "source": "historical-estimate"
+    },
+    "2026-05-10": {
+      "date": "2026-05-10",
+      "weatherCode": 1,
+      "category": "partly-cloudy",
+      "temperatureMax": 22.8,
+      "temperatureMin": 8.1,
+      "precipitationSum": 0,
+      "windSpeedMax": 13.9,
+      "source": "historical-estimate"
+    },
+    "2026-05-17": {
+      "date": "2026-05-17",
+      "weatherCode": 3,
+      "category": "partly-cloudy",
+      "temperatureMax": 19.4,
+      "temperatureMin": 8.4,
+      "precipitationSum": 0,
+      "windSpeedMax": 19.1,
+      "source": "historical-estimate"
+    }
+  },
+  "ajax": {},
+  "feyenoord": {}
+}

--- a/lib/weather.server.ts
+++ b/lib/weather.server.ts
@@ -1,0 +1,94 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import type { Fixture } from "./data";
+import {
+  parseDailyResponse,
+  type OpenMeteoDailyResponse,
+  type WeatherData,
+  type WeatherFile,
+} from "./weather";
+
+/**
+ * Server-side weather loading (called from page.tsx).
+ *
+ * 1. Reads pre-computed data from weather.json (historical + estimates)
+ * 2. Fetches live forecast for dates within 16-day window not in the JSON
+ * 3. Returns merged result
+ */
+export async function loadWeather(
+  clubId: string,
+  fixtures: Fixture[],
+  coordinates: { latitude: number; longitude: number },
+  leagueDataDir: string
+): Promise<Record<string, WeatherData>> {
+  const result: Record<string, WeatherData> = {};
+
+  // 1. Read pre-computed weather data
+  try {
+    const raw = readFileSync(
+      join(process.cwd(), leagueDataDir, "weather.json"),
+      "utf-8"
+    );
+    const file = JSON.parse(raw) as WeatherFile;
+    const clubWeather = file[clubId] as
+      | Record<string, WeatherData>
+      | undefined;
+    if (clubWeather) {
+      Object.assign(result, clubWeather);
+    }
+  } catch {
+    // weather.json doesn't exist yet — continue with live forecast only
+  }
+
+  // 2. Find fixture dates for this club that need live forecast
+  const clubFixtureDates = fixtures
+    .filter((f) => f.homeTeam === clubId || f.awayTeam === clubId)
+    .map((f) => f.date.slice(0, 10));
+
+  const now = new Date();
+  const forecastLimit = new Date(now);
+  forecastLimit.setDate(forecastLimit.getDate() + 16);
+
+  const missingDates = clubFixtureDates.filter((date) => {
+    if (result[date]) return false;
+    const d = new Date(date);
+    return d >= now && d <= forecastLimit;
+  });
+
+  // 3. Fetch live forecast for missing dates within 16-day window
+  if (missingDates.length > 0) {
+    const sorted = [...missingDates].sort();
+    const startDate = sorted[0];
+    const endDate = sorted[sorted.length - 1];
+
+    try {
+      const response = await fetch(
+        `https://api.open-meteo.com/v1/forecast?${new URLSearchParams({
+          latitude: String(coordinates.latitude),
+          longitude: String(coordinates.longitude),
+          start_date: startDate,
+          end_date: endDate,
+          daily:
+            "weather_code,temperature_2m_max,temperature_2m_min,precipitation_sum,wind_speed_10m_max",
+          timezone: "Europe/Amsterdam",
+        })}`,
+        { next: { revalidate: 600 } }
+      );
+
+      if (response.ok) {
+        const data = (await response.json()) as OpenMeteoDailyResponse;
+        const forecasts = parseDailyResponse(data, "forecast");
+        const missingSet = new Set(missingDates);
+        for (const forecast of forecasts) {
+          if (missingSet.has(forecast.date)) {
+            result[forecast.date] = forecast;
+          }
+        }
+      }
+    } catch {
+      // Live forecast failed — continue without it
+    }
+  }
+
+  return result;
+}

--- a/lib/weather.ts
+++ b/lib/weather.ts
@@ -1,0 +1,119 @@
+// --- Types ---
+
+export type WeatherSource = "forecast" | "historical" | "historical-estimate";
+
+export type WeatherCategory =
+  | "sunny"
+  | "partly-cloudy"
+  | "cloudy"
+  | "fog"
+  | "drizzle"
+  | "rain"
+  | "snow"
+  | "thunderstorm";
+
+export interface WeatherData {
+  date: string;
+  weatherCode: number;
+  category: WeatherCategory;
+  temperatureMax: number;
+  temperatureMin: number;
+  precipitationSum: number;
+  windSpeedMax: number;
+  source: WeatherSource;
+}
+
+export interface WeatherFile {
+  [clubId: string]: Record<string, WeatherData> | string;
+  fetchedAt: string;
+}
+
+// --- WMO weather code mapping ---
+
+export function wmoToCategory(code: number): WeatherCategory {
+  if (code === 0) return "sunny";
+  if (code <= 3) return "partly-cloudy";
+  if (code <= 49) return "fog";
+  if (code <= 59) return "drizzle";
+  if (code <= 69) return "rain";
+  if (code <= 79) return "snow";
+  if (code <= 84) return "rain";
+  if (code <= 86) return "snow";
+  if (code <= 99) return "thunderstorm";
+  return "cloudy";
+}
+
+export function categoryToIcon(category: WeatherCategory): string {
+  const icons: Record<WeatherCategory, string> = {
+    sunny: "\u2600\uFE0F",
+    "partly-cloudy": "\u26C5",
+    cloudy: "\u2601\uFE0F",
+    fog: "\uD83C\uDF2B\uFE0F",
+    drizzle: "\uD83C\uDF26\uFE0F",
+    rain: "\uD83C\uDF27\uFE0F",
+    snow: "\u2744\uFE0F",
+    thunderstorm: "\u26C8\uFE0F",
+  };
+  return icons[category];
+}
+
+// --- Open-Meteo fetch helper ---
+
+export interface OpenMeteoDailyResponse {
+  daily: {
+    time: string[];
+    weather_code: number[];
+    temperature_2m_max: number[];
+    temperature_2m_min: number[];
+    precipitation_sum: number[];
+    wind_speed_10m_max: number[];
+  };
+}
+
+export async function fetchOpenMeteoDaily(
+  lat: number,
+  lon: number,
+  startDate: string,
+  endDate: string,
+  endpoint: "forecast" | "archive"
+): Promise<OpenMeteoDailyResponse> {
+  const base =
+    endpoint === "forecast"
+      ? "https://api.open-meteo.com/v1/forecast"
+      : "https://archive-api.open-meteo.com/v1/archive";
+
+  const params = new URLSearchParams({
+    latitude: String(lat),
+    longitude: String(lon),
+    start_date: startDate,
+    end_date: endDate,
+    daily:
+      "weather_code,temperature_2m_max,temperature_2m_min,precipitation_sum,wind_speed_10m_max",
+    timezone: "Europe/Amsterdam",
+  });
+
+  const res = await fetch(`${base}?${params}`);
+  if (!res.ok) {
+    throw new Error(
+      `Open-Meteo ${endpoint} error ${res.status}: ${await res.text()}`
+    );
+  }
+  return res.json() as Promise<OpenMeteoDailyResponse>;
+}
+
+export function parseDailyResponse(
+  response: OpenMeteoDailyResponse,
+  source: WeatherSource
+): WeatherData[] {
+  const { daily } = response;
+  return daily.time.map((date, i) => ({
+    date,
+    weatherCode: daily.weather_code[i],
+    category: wmoToCategory(daily.weather_code[i]),
+    temperatureMax: daily.temperature_2m_max[i],
+    temperatureMin: daily.temperature_2m_min[i],
+    precipitationSum: daily.precipitation_sum[i],
+    windSpeedMax: daily.wind_speed_10m_max[i],
+    source,
+  }));
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint",
     "fetch-data": "tsx scripts/fetch-data.ts",
     "simulate": "tsx scripts/simulate.ts",
-    "update-data": "npm run fetch-data && npm run simulate",
+    "fetch-weather": "tsx scripts/fetch-weather.ts",
+    "update-data": "npm run fetch-data && npm run simulate && npm run fetch-weather",
     "build-all": "tsx scripts/build-all.ts"
   },
   "dependencies": {

--- a/scripts/fetch-weather.ts
+++ b/scripts/fetch-weather.ts
@@ -1,0 +1,191 @@
+/**
+ * npm run fetch-weather
+ *
+ * Fetches historical weather data for match days and stores it in weather.json.
+ * - Past dates → Historical API (actual weather)
+ * - Future dates >16 days → Historical API for same date last year (estimate)
+ * - Dates within 16 days → skipped (handled server-side at request time)
+ *
+ * Uses Open-Meteo (free, no API key required).
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
+import { join } from "path";
+import { resolveLeague } from "../config/env";
+import { clubs } from "../config/clubs";
+import type { Fixture } from "../lib/data";
+import {
+  fetchOpenMeteoDaily,
+  parseDailyResponse,
+  type WeatherData,
+  type WeatherFile,
+} from "../lib/weather";
+
+interface StandingsFile {
+  teams: unknown[];
+  remainingFixtures: Fixture[];
+  fetchedAt: string;
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function main() {
+  const league = resolveLeague();
+  console.log(`League: ${league.name} (${league.id})`);
+
+  const dataDir = join(process.cwd(), league.dataDir);
+
+  // Read fixtures from standings.json
+  const standingsPath = join(dataDir, "standings.json");
+  if (!existsSync(standingsPath)) {
+    console.error(
+      `${league.dataDir}/standings.json niet gevonden. Draai eerst: npm run fetch-data`
+    );
+    process.exit(1);
+  }
+
+  const standings = JSON.parse(
+    readFileSync(standingsPath, "utf-8")
+  ) as StandingsFile;
+
+  // Load existing weather data to skip already-fetched dates
+  const weatherPath = join(dataDir, "weather.json");
+  let existing: WeatherFile = { fetchedAt: "" };
+  if (existsSync(weatherPath)) {
+    existing = JSON.parse(readFileSync(weatherPath, "utf-8")) as WeatherFile;
+  }
+
+  // Find clubs in this league
+  const leagueClubs = Object.values(clubs).filter(
+    (c) => c.leagueId === league.id
+  );
+
+  const now = new Date();
+  const today = now.toISOString().slice(0, 10);
+  const forecastLimit = new Date(now);
+  forecastLimit.setDate(forecastLimit.getDate() + 16);
+  const forecastLimitStr = forecastLimit.toISOString().slice(0, 10);
+
+  for (const club of leagueClubs) {
+    console.log(`\nWeather voor ${club.name}...`);
+
+    const existingClubWeather = (existing[club.id] as Record<string, WeatherData>) ?? {};
+    const result: Record<string, WeatherData> = { ...existingClubWeather };
+
+    // Get fixture dates for this club
+    const clubFixtureDates = [
+      ...new Set(
+        standings.remainingFixtures
+          .filter((f) => f.homeTeam === club.id || f.awayTeam === club.id)
+          .map((f) => f.date.slice(0, 10))
+      ),
+    ].sort();
+
+    // Categorize dates
+    const historicalDates: string[] = [];
+    const estimateDates: string[] = [];
+
+    for (const date of clubFixtureDates) {
+      if (result[date]) {
+        // Already have data — skip unless it was an estimate and now we can get actual
+        if (date < today && result[date].source === "historical-estimate") {
+          historicalDates.push(date);
+        }
+        continue;
+      }
+
+      if (date < today) {
+        historicalDates.push(date);
+      } else if (date > forecastLimitStr) {
+        estimateDates.push(date);
+      }
+      // Dates within forecast window are handled server-side
+    }
+
+    // Fetch historical weather (actual past data)
+    if (historicalDates.length > 0) {
+      console.log(`  Historical: ${historicalDates.length} dates`);
+      const sorted = [...historicalDates].sort();
+      const startDate = sorted[0];
+      const endDate = sorted[sorted.length - 1];
+
+      try {
+        const response = await fetchOpenMeteoDaily(
+          club.coordinates.latitude,
+          club.coordinates.longitude,
+          startDate,
+          endDate,
+          "archive"
+        );
+        const data = parseDailyResponse(response, "historical");
+        const dateSet = new Set(historicalDates);
+        for (const d of data) {
+          if (dateSet.has(d.date)) {
+            result[d.date] = d;
+          }
+        }
+      } catch (err) {
+        console.warn(
+          `  Historical fetch mislukt: ${err instanceof Error ? err.message : err}`
+        );
+      }
+      await sleep(500); // rate limit courtesy
+    }
+
+    // Fetch historical estimates (same date last year)
+    if (estimateDates.length > 0) {
+      console.log(`  Historical estimates: ${estimateDates.length} dates`);
+      const lastYearDates = estimateDates.map((d) => {
+        const date = new Date(d);
+        date.setFullYear(date.getFullYear() - 1);
+        return { original: d, lastYear: date.toISOString().slice(0, 10) };
+      });
+
+      const sorted = [...lastYearDates].sort((a, b) =>
+        a.lastYear.localeCompare(b.lastYear)
+      );
+      const startDate = sorted[0].lastYear;
+      const endDate = sorted[sorted.length - 1].lastYear;
+
+      try {
+        const response = await fetchOpenMeteoDaily(
+          club.coordinates.latitude,
+          club.coordinates.longitude,
+          startDate,
+          endDate,
+          "archive"
+        );
+        const data = parseDailyResponse(response, "historical-estimate");
+        const dateMap = new Map(
+          lastYearDates.map((d) => [d.lastYear, d.original])
+        );
+        for (const d of data) {
+          const originalDate = dateMap.get(d.date);
+          if (originalDate) {
+            result[originalDate] = { ...d, date: originalDate };
+          }
+        }
+      } catch (err) {
+        console.warn(
+          `  Estimate fetch mislukt: ${err instanceof Error ? err.message : err}`
+        );
+      }
+      await sleep(500);
+    }
+
+    existing[club.id] = result;
+    console.log(`  ${Object.keys(result).length} dates totaal`);
+  }
+
+  existing.fetchedAt = new Date().toISOString();
+  mkdirSync(dataDir, { recursive: true });
+  writeFileSync(weatherPath, JSON.stringify(existing, null, 2));
+  console.log(`\n${league.dataDir}/weather.json opgeslagen`);
+}
+
+main().catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds Open-Meteo weather forecasts to match day displays (hero stats, best case view, timeline)
- Two-tier strategy: historical/estimate weather pre-fetched via `npm run fetch-weather`, live 16-day forecast fetched server-side with ISR (10-min revalidate)
- New `WeatherBadge` component shows weather emoji, temperature range, and "(verwacht)" for historical estimates

## Test plan
- [ ] Run `npm run fetch-weather` — creates `data/{league}/weather.json` with historical data
- [ ] Run `npm run build` — succeeds, page uses ISR (revalidate 600)
- [ ] Run `npm run dev` — weather badges visible in hero stat cards, best case view, and timeline
- [ ] Dates in forecast window show live weather; dates beyond show "(verwacht)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)