### PR TITLE
fix: mobile scaling and responsive layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -20,3 +20,7 @@ body { background: var(--dark); color: #fff; font-family: var(--font-body); over
 ::-webkit-scrollbar { width: 5px; }
 ::-webkit-scrollbar-track { background: var(--dark-2); }
 ::-webkit-scrollbar-thumb { background: var(--club-primary); border-radius: 3px; }
+
+@media (max-width: 480px) {
+  section { padding-left: 1rem !important; padding-right: 1rem !important; }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,6 +30,8 @@ const templateVars = {
 
 export const viewport: Viewport = {
   themeColor: club.primaryColor,
+  width: "device-width",
+  initialScale: 1,
 };
 
 export const metadata: Metadata = {

--- a/components/BestCaseView.tsx
+++ b/components/BestCaseView.tsx
@@ -161,9 +161,10 @@ export default function BestCaseView({
           style={{
             border: "1px solid var(--dark-4)",
             borderRadius: "4px",
-            overflow: "hidden",
+            overflowX: "auto",
           }}
         >
+          <div style={{ minWidth: "360px" }}>
           {/* Header row */}
           <div
             style={{
@@ -272,6 +273,7 @@ export default function BestCaseView({
               </p>
             </div>
           ))}
+          </div>
         </div>
       </div>
     </section>

--- a/components/ChampionshipTimeline.tsx
+++ b/components/ChampionshipTimeline.tsx
@@ -73,10 +73,10 @@ export default function ChampionshipTimeline({
                 key={dp.date}
                 style={{
                   display: "grid",
-                  gridTemplateColumns: "110px 1fr 70px",
+                  gridTemplateColumns: "100px 1fr 65px",
                   alignItems: "center",
-                  gap: "1.5rem",
-                  padding: "1.25rem 1.5rem",
+                  gap: "0.75rem",
+                  padding: "1.25rem 1rem",
                   borderBottom: i < dates.length - 1 ? "1px solid var(--dark-4)" : "none",
                   background: isTop ? "var(--club-primary-glow)" : "transparent",
                   transition: "background 0.2s",

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -188,9 +188,9 @@ export default function HeroSection({
 
         {/* Three stat cards */}
         <div
+          className="stat-cards-grid"
           style={{
             display: "grid",
-            gridTemplateColumns: "repeat(3, 1fr)",
             gap: "1px",
             background: "var(--gray)",
             border: "1px solid var(--gray)",
@@ -308,12 +308,14 @@ export default function HeroSection({
               {texts.explanationRivalsLabel}
             </p>
 
+            <div style={{ overflowX: "auto" }}>
             <table
               style={{
                 width: "100%",
                 borderCollapse: "collapse",
                 marginBottom: "1.25rem",
                 fontSize: "0.82rem",
+                minWidth: "300px",
               }}
             >
               <thead>
@@ -339,6 +341,7 @@ export default function HeroSection({
                 ))}
               </tbody>
             </table>
+            </div>
 
             <p style={{ marginBottom: "0.5rem" }}>
               <span
@@ -480,6 +483,14 @@ export default function HeroSection({
         @keyframes pulse {
           0%, 100% { opacity: 1; transform: scaleY(1); }
           50% { opacity: 0.5; transform: scaleY(0.8); }
+        }
+        .stat-cards-grid {
+          grid-template-columns: repeat(3, 1fr);
+        }
+        @media (max-width: 480px) {
+          .stat-cards-grid {
+            grid-template-columns: 1fr;
+          }
         }
       `}</style>
     </section>

--- a/components/StandingsTable.tsx
+++ b/components/StandingsTable.tsx
@@ -51,9 +51,10 @@ export default function StandingsTable({
           style={{
             border: "1px solid var(--dark-4)",
             borderRadius: "4px",
-            overflow: "hidden",
+            overflowX: "auto",
           }}
         >
+          <div style={{ minWidth: "480px" }}>
           {/* Header */}
           <div
             style={{
@@ -185,6 +186,7 @@ export default function StandingsTable({
               </div>
             );
           })}
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Add missing `width`/`initialScale` to viewport meta — root cause of the mobile scaling issue
- StandingsTable and BestCaseView fixture grids scroll horizontally on narrow screens
- HeroSection stat cards collapse to single column below 480px
- Reduce padding/gap in ChampionshipTimeline for mobile

## Test plan
- [ ] Open site on mobile device (or DevTools mobile emulation)
- [ ] Verify page renders at device width, not scaled down
- [ ] Check StandingsTable scrolls horizontally on small screens
- [ ] Check stat cards stack vertically on narrow screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)